### PR TITLE
fix 404 problems at /downloads/gem_j_wga etc

### DIFF
--- a/docker/nginx/nginx.conf
+++ b/docker/nginx/nginx.conf
@@ -78,6 +78,10 @@ http {
       return 301 /public/$is_args$args;
     }
 
+    location = /downloads {
+      return 301 /downloads/$is_args$args;
+    }
+
     location /jbrowse/ {
       rewrite /jbrowse/(.*) /$1 break;
       proxy_pass http://jbrowse:8080;
@@ -111,6 +115,12 @@ http {
     }
 
     location /public/ {
+      autoindex on;
+      autoindex_exact_size off;
+    }
+
+    location /downloads/ {
+      root /var/www/public/;
       autoindex on;
       autoindex_exact_size off;
     }


### PR DESCRIPTION
fix 404 problems at /downloads/gem_j_wga and downloads/release/current which are linked from /doc/downloads